### PR TITLE
Adding StatusBar Plugin to fix status bar styles on iOS and Android

### DIFF
--- a/app/main-page.xml
+++ b/app/main-page.xml
@@ -1,4 +1,7 @@
-<Page xmlns="http://schemas.nativescript.org/tns.xsd" loaded="pageLoaded">
+<Page xmlns="http://schemas.nativescript.org/tns.xsd"
+      xmlns:s="nativescript-statusbar"
+      loaded="pageLoaded">
+ <s:StatusBar ios:barStyle="light" android:barStyle="#00A7F7" />
  <Page.actionBar>
     <ActionBar title="{N}atty Chat" cssClass="custom-action-bar">
     </ActionBar>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	},
 	"dependencies": {
 		"nativescript-iqkeyboardmanager": "^1.0.0",
+		"nativescript-statusbar": "^1.0.0",
 		"tns-core-modules": "1.6.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Added the [Status Bar Plugin](https://www.npmjs.com/package/nativescript-statusbar) to fix the black status bar text on iOS and the grey status bar on Android.

![chat-with-status-bar](https://cloud.githubusercontent.com/assets/686963/13575609/67ce7926-e44f-11e5-9ed8-d64632e6cd95.png)
